### PR TITLE
EnumerableSerializer incorrect output when used inside another enumeration

### DIFF
--- a/src/Microsoft.Hadoop.Avro/Serializers/EnumerableSerializer.cs
+++ b/src/Microsoft.Hadoop.Avro/Serializers/EnumerableSerializer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Hadoop.Avro.Serializers
                 Expression.Assign(buffer, Expression.New(listType)),
                 Expression.Assign(counter, Expression.Constant(0)),
                 Expression.Assign(enumerator, Expression.Call(value, getEnumerator)),
+                Expression.Assign(chunkCounter, ConstantZero),
                 Expression.Loop(
                     Expression.IfThenElse(
                         Expression.NotEqual(Expression.Call(enumerator, moveNext), Expression.Constant(false)),


### PR DESCRIPTION
Hello, I found unexpected serialization behavior when tried to serialize complex enumerations.
For example we have a Message to serialize:
```
public class Message
{
  public List<Dictionary<int, int>> Items { get; set; }
}
```
Let's do a test (extension calls are used as a short): 
```
public static void Main()
{
  Message example = new Message()
  {
	Items = new List<Dictionary<int, int>>()
	{
	  new Dictionary<int, int>() { { 11, 11 } },
	  new Dictionary<int, int>() { { 13, 13 } }
	}
  };
  byte[] avro = example.ToAvro(); // produced bytes: 2 4 2 2 22 22 0 2 2 0 0 
		                  // when expected is: 2 4 2 2 22 22 0 2 2 26 26 0 0
  Message back = avro.FromAvro<Message>();
}
```
EnumerableSerializer do unexpected break when processing a second member of a sequence.
It happens because of a serializer instance that loops over a many members. 
Reset chunkCounter on every serializer block helps to correct an output.